### PR TITLE
Add KDTree-based cell indexing and integrate _CellConnector

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -3,4 +3,5 @@ grpcio==1.69.0
 grpcio-tools==1.69.0
 numpy==2.2.1
 pydantic==2.10.4
+scipy==1.15.2
 tomli==2.2.1

--- a/src/services/simulation_service/core/connectors/open_darts.py
+++ b/src/services/simulation_service/core/connectors/open_darts.py
@@ -185,11 +185,6 @@ class OpenDartsConnector(ConnectorInterface):
         wells and reservoir cells are accurately identified considering reservoir geometry,
         discretization, and perforation coordinates.
 
-        Args:
-            [Include parameters here, for example:]
-            well_name (str): Identifier or name of the well to locate perforation-related cells.
-            perforations (List[Tuple[float, float, float]]): List of perforation coordinates (X, Y, Z) associated with the well.
-
         Returns:
             List[int]: List of cell indices within the reservoir grid corresponding to the provided perforations.
 

--- a/src/services/simulation_service/core/connectors/open_darts.py
+++ b/src/services/simulation_service/core/connectors/open_darts.py
@@ -109,7 +109,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def run(
-            config: SerializedJson,
+        config: SerializedJson,
     ) -> SimulationResults:
         """
         Start reservoir simulator with given config and model in main.py
@@ -138,7 +138,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _get_broadcast_results(
-            stdout: str,
+        stdout: str,
     ) -> SimulationResults:
         template = OpenDartsConnector.MsgTemplate
         re_key = r"(\w+)"  # str
@@ -161,7 +161,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def broadcast_result(
-            key: SimulationResultType, value: float | Sequence[float]
+        key: SimulationResultType, value: float | Sequence[float]
     ) -> None:
         """
         Use for broadcast given simulation results to stdout
@@ -173,8 +173,8 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def get_well_connection_cells(
-            well_management_service_result: WellManagementServiceResultSchema,
-            struct_reservoir: _StructReservoirProtocol,
+        well_management_service_result: WellManagementServiceResultSchema,
+        struct_reservoir: _StructReservoirProtocol,
     ) -> dict[WellName, tuple[GridCell, ...]]:
         """
         Retrieve the connection cells for a given well, identifying which reservoir grid cells
@@ -231,7 +231,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _global_idx_to_grid_cell(
-            idx: int, struct_reservoir: _StructReservoirProtocol
+        idx: int, struct_reservoir: _StructReservoirProtocol
     ) -> GridCell:
         nx = struct_reservoir.nx
         ny = struct_reservoir.ny
@@ -244,8 +244,8 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _filter_perforations_inside_reservoir(
-            struct_reservoir: _StructReservoirProtocol,
-            well_perforations_points: tuple[Point, ...],
+        struct_reservoir: _StructReservoirProtocol,
+        well_perforations_points: tuple[Point, ...],
     ) -> tuple[Point, ...]:
         dx = struct_reservoir.global_data["dx"]
         dy = struct_reservoir.global_data["dy"]
@@ -271,9 +271,9 @@ class OpenDartsConnector(ConnectorInterface):
 
 class _CellConnector:
     """
-        Notes:
-        - This class explicitly depends on 'scipy' for KD-tree spatial queries. Ensure 'scipy' is installed
-          through the 'open-darts' dependency specification
+    Notes:
+    - This class explicitly depends on 'scipy' for KD-tree spatial queries. Ensure 'scipy' is installed
+      through the 'open-darts' dependency specification
     """
 
     def __init__(self, discretizer: _StructDiscretizerProtocol) -> None:

--- a/src/services/simulation_service/core/connectors/open_darts.py
+++ b/src/services/simulation_service/core/connectors/open_darts.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Protocol, Sequence, TypedDict
 
 import numpy as np
 import numpy.typing as npt
+from scipy.spatial import KDTree
 
 from .common import (
     ConnectorInterface,
@@ -67,8 +68,6 @@ class _StructReservoirProtocol(Protocol):
     discretizer: _StructDiscretizerProtocol
     global_data: _GlobalData
 
-    def find_cell_index(self, coord: Point) -> int: ...
-
 
 def open_darts_input_configuration_injector(func: Callable[..., None]) -> Any:
     """
@@ -110,7 +109,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def run(
-        config: SerializedJson,
+            config: SerializedJson,
     ) -> SimulationResults:
         """
         Start reservoir simulator with given config and model in main.py
@@ -139,7 +138,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _get_broadcast_results(
-        stdout: str,
+            stdout: str,
     ) -> SimulationResults:
         template = OpenDartsConnector.MsgTemplate
         re_key = r"(\w+)"  # str
@@ -162,7 +161,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def broadcast_result(
-        key: SimulationResultType, value: float | Sequence[float]
+            key: SimulationResultType, value: float | Sequence[float]
     ) -> None:
         """
         Use for broadcast given simulation results to stdout
@@ -174,13 +173,44 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def get_well_connection_cells(
-        well_management_service_result: WellManagementServiceResultSchema,
-        struct_reservoir: _StructReservoirProtocol,
+            well_management_service_result: WellManagementServiceResultSchema,
+            struct_reservoir: _StructReservoirProtocol,
     ) -> dict[WellName, tuple[GridCell, ...]]:
+        """
+        Retrieve the connection cells for a given well, identifying which reservoir grid cells
+        correspond to the well's perforations.
+
+        This method maps well perforations onto the reservoir's discretized cells, potentially
+        using spatial querying (e.g., through a KD-tree). It ensures that connections between
+        wells and reservoir cells are accurately identified considering reservoir geometry,
+        discretization, and perforation coordinates.
+
+        Args:
+            [Include parameters here, for example:]
+            well_name (str): Identifier or name of the well to locate perforation-related cells.
+            perforations (List[Tuple[float, float, float]]): List of perforation coordinates (X, Y, Z) associated with the well.
+
+        Returns:
+            List[int]: List of cell indices within the reservoir grid corresponding to the provided perforations.
+
+        Raises:
+            ValueError: If provided perforation coordinates are invalid or outside the reservoir bounds.
+            RuntimeError: If internal spatial querying fails due to invalid KD-tree or spatial data setup.
+
+
+        Notes:
+            - Ensure that the internal KD-tree or spatial data used for find operations is initialized and updated accurately.
+            - Coordinate systems (units and orientation) must be consistent with reservoir modeling conventions.
+
+        """
+
         result: dict[WellName, tuple[GridCell, ...]] = {}
         wells_with_perforations_points: dict[WellName, tuple[Point, ...]] = (
             extract_well_with_perforations_points(well_management_service_result)
         )
+
+        cell_connector = _CellConnector(struct_reservoir.discretizer)
+
         for well_name, perforations_points in wells_with_perforations_points.items():
             filtered_perforations_points = (
                 OpenDartsConnector._filter_perforations_inside_reservoir(
@@ -188,8 +218,7 @@ class OpenDartsConnector(ConnectorInterface):
                 )
             )
             global_perforation_idx: list[int] = [
-                struct_reservoir.find_cell_index(p)
-                for p in filtered_perforations_points
+                cell_connector.find_cell_index(p) for p in filtered_perforations_points
             ]
             unique_global_perforation_idx = list(set(global_perforation_idx))
             unique_perforation_grid_cells = [
@@ -202,7 +231,7 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _global_idx_to_grid_cell(
-        idx: int, struct_reservoir: _StructReservoirProtocol
+            idx: int, struct_reservoir: _StructReservoirProtocol
     ) -> GridCell:
         nx = struct_reservoir.nx
         ny = struct_reservoir.ny
@@ -215,8 +244,8 @@ class OpenDartsConnector(ConnectorInterface):
 
     @staticmethod
     def _filter_perforations_inside_reservoir(
-        struct_reservoir: _StructReservoirProtocol,
-        well_perforations_points: tuple[Point, ...],
+            struct_reservoir: _StructReservoirProtocol,
+            well_perforations_points: tuple[Point, ...],
     ) -> tuple[Point, ...]:
         dx = struct_reservoir.global_data["dx"]
         dy = struct_reservoir.global_data["dy"]
@@ -238,3 +267,18 @@ class OpenDartsConnector(ConnectorInterface):
         filtered_perforations_points = well_perforations_points_ar[in_bounds]
 
         return tuple(filtered_perforations_points)
+
+
+class _CellConnector:
+    """
+        Notes:
+        - This class explicitly depends on 'scipy' for KD-tree spatial queries. Ensure 'scipy' is installed
+          through the 'open-darts' dependency specification
+    """
+
+    def __init__(self, discretizer: _StructDiscretizerProtocol) -> None:
+        self._kd_tree = KDTree(discretizer.centroids_all_cells)
+
+    def find_cell_index(self, coord: Point) -> int:
+        _, idx = self._kd_tree.query(coord)
+        return idx

--- a/tests/simulation_service_tests/test_connectors.py
+++ b/tests/simulation_service_tests/test_connectors.py
@@ -7,7 +7,6 @@ import pytest
 
 from services.simulation_service.core.connectors.common import (
     GridCell,
-    Point,
     WellManagementServiceResultSchema,
     WellName,
 )
@@ -1418,20 +1417,6 @@ def mock_struct_reservoir(
         nz: int = 10
         discretizer: _StructDiscretizerProtocol = mock_discretizer
         global_data: _GlobalData = global_data_mock
-
-        def find_cell_index(self, coord: Point) -> int:
-            """
-            Copied from open-darts repository
-            """
-            min_dis = None
-            idx = None
-            for j, centroid in enumerate(self.discretizer.centroids_all_cells):
-                dis = np.linalg.norm(np.array(coord) - centroid)
-                if (min_dis is not None and dis < min_dis) or min_dis is None:
-                    min_dis = dis
-                    idx = j
-            assert idx is not None  # added on top of open-darts to silence mypy
-            return idx
 
     return MockStructReservoir()
 


### PR DESCRIPTION
Replaced the manual cell indexing logic with a KDTree implementation for improved performance and maintainability. Introduced a new `_CellConnector` class to encapsulate this functionality, which relies on the `scipy` library. Updated `requirements-release.txt` to include `scipy` as a dependency.

# Pull Request Title

- **Type of Change**:
  - [ ] New feature
  - [ ] Bug fix
  - [x] Code refactoring
  - [ ] Documentation update
  - [ x] Other (please describe): Performance improvements 

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Skip test - Please provide an explanation why you skip tests


