### PR TITLE
Prune dangling docker images

### DIFF
--- a/src/services/simulation_service/core/service/simulation_service.py
+++ b/src/services/simulation_service/core/service/simulation_service.py
@@ -68,6 +68,21 @@ class SimulationService:
             SimulationService._SERVER_HOST,
             SimulationService._SERVER_PORT,
         )
+
+        # Clean up dangling images before starting cluster.
+        # Note: dangling images are images with both <none> as their repository and tag
+        try:
+            logger.info("Pruning dangling Docker images...")
+            result = subprocess.run(
+                ["docker", "image", "prune", "-f"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception as e:
+            logger.warning("Failed to prune Docker images: %s", str(e))
+            raise
+
         with core_directory():
             try:
                 result = subprocess.run(


### PR DESCRIPTION
# Dangling Images bugfix

## Description

Added functionality for pruning dangling docker images.  
NOTE: 'if server & worker already exist in docker images then build should be skipped' is already satisfied with docker compose command.

- **Type of Change**:
  - [ ] New feature
  - [x] Bug fix
  - [ ] Code refactoring
  - [ ] Documentation update
  - [ ] Other (please describe):

## Related Issues

- Issue #41 

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Skip test - Please provide an explanation why you skip tests

_We encourage you to keep the code coverage percentage at 90% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

**Testing Environment**:
- Python Version: 3.12
- OS: Ubuntu 20.04

## Checklist

Ensure that all the following tasks are completed before submitting your PR:

- [x] Code is formatted and has been linted using 'makefile' run-check option
- [x] New and existing tests pass locally.
- [  ] All relevant documentation has been updated (e.g., docstrings, README, etc.).
- [x] Dependencies have been updated, and `requirements.txt` or `pyproject.toml` has been updated accordingly.
- [ ] This PR has been reviewed by at least one other developer.
