### PR TITLE
    Update CLI arg from n_size to population_size for clarity

### DIFF
--- a/src/interfaces/cli.py
+++ b/src/interfaces/cli.py
@@ -66,7 +66,7 @@ def cli():
         run_risk_management(
             problem_definition=problem_definition,
             simulation_model_archive=args.model_file,
-            n_size=args.n_size,
+            n_size=args.population_size,
             patience=args.patience,
             max_generations=args.max_generations,
         )


### PR DESCRIPTION
    Replaced the 'n_size' argument with 'population_size' in the run_risk_management call. This change improves parameter naming consistency and enhances code readability.

